### PR TITLE
Ilia fix queery stories tab in homepage

### DIFF
--- a/components/Organisms/Common/QueeryStoryTabs/index.jsx
+++ b/components/Organisms/Common/QueeryStoryTabs/index.jsx
@@ -1,0 +1,86 @@
+import {Tabs} from '@mantine/core';
+import {NewPost} from '../../../Templates/Post/NewPost';
+import {Spacer} from '../../../Atoms/Common/Spacer';
+import React, {useEffect, useState} from 'react';
+import axios from 'axios';
+
+export function QueeryStoryTabs({}) {
+    const [activeTab, setActiveTab] = useState('queery');
+
+    const [stories, setStories] = useState(null);
+    const [queeries, setQueeries] = useState(null);
+
+    useEffect(() => {
+        (async function () {
+            try {
+                console.log('fetching stories');
+                const response = await axios.get(`/api/posts/${activeTab}`);
+                console.log('response', response);
+                if (activeTab === 'queery') {
+                    setQueeries([...response.data]);
+                } else {
+                    setStories([...response.data]);
+                }
+            } catch (error) {
+                debugger;
+                console.error(error);
+            }
+        })();
+    }, [activeTab]);
+
+    return (
+        <Tabs color="pink" value={activeTab} onTabChange={setActiveTab}>
+            <Tabs.List grow>
+                <Tabs.Tab value="queery"> Queeries </Tabs.Tab>
+                <Tabs.Tab value="story">Stories </Tabs.Tab>
+            </Tabs.List>
+
+            <Tabs.Panel value="queery">
+                {queeries === null ? (
+                    <div>Loading Queeries...</div>
+                ) :
+                    (
+                        queeries.map((queery) => (
+                            <>
+                                <NewPost
+                                    key={queery.postId}
+                                    postId={queery.postId}
+                                    postType={queery.postType ?? 'Queery'}
+                                    username={queery.authorUser?.username ?? 'Anonymous'}
+                                    date={queery.createdAt}
+                                    title={queery.postTitle}
+                                    content={queery.postContent}
+                                    tags={queery.postTags}
+                                />
+                                <Spacer size={10}/>
+                            </>
+                        ))
+                    )
+                }
+            </Tabs.Panel>
+            <Tabs.Panel value="story">
+                {stories === null ? (
+                    <div>Loading stories...</div>
+                ) : (
+                    stories.map((story) => (
+
+                        <>
+                            <NewPost
+                                key={story.postId}
+                                postId={story.postId}
+                                postType={story.postType ?? 'Story'}
+                                username={story.authorUser?.username ?? 'Anonymous'}
+                                date={story.createdAt}
+                                title={story.postTitle}
+                                content={story.postContent}
+                                tags={story.postTags}
+                            />
+                            <Spacer size={10}/>
+                        </>
+                    ))
+                )
+                }
+            </Tabs.Panel>
+        </Tabs>
+    );
+}

--- a/pages/homepage/index.js
+++ b/pages/homepage/index.js
@@ -6,11 +6,10 @@ import {queeryQuestions} from '../../data/qotd';
 import {API_SERVER} from '../../lib/constants';
 import {Background} from '../../styles/globals';
 import {SearchAndFilter} from '../../components/Organisms/Common/SearchAndFilter';
-import {Space, Tabs} from '@mantine/core';
 import styled from 'styled-components';
 import {ScrollToTopButton} from '../../components/Atoms/Common/ScrollToTopButton';
 import React, {useEffect, useState} from 'react';
-import {Loader} from '../../components/Atoms/Common/Loader';
+import {QueeryStoryTabs} from '../../components/Organisms/Common/QueeryStoryTabs';
 
 export const StickyDiv = styled.div`
   position: sticky;
@@ -42,28 +41,6 @@ export default function Homepage(props) {
     // const [search, setSearch] = useState('');
     // const [filter, setFilter] = useState('All');
     // const [filteredPosts, setFilteredPosts] = useState([]);
-    const [activeTab, setActiveTab] = useState('queery');
-
-    const [stories, setStories] = useState(null);
-    const [queeries, setQueeries] = useState(null);
-
-    useEffect(() => {
-        (async function () {
-            try {
-                console.log('fetching stories');
-                const response = await axios.get(`/api/posts/${activeTab}`);
-                console.log('response', response);
-                if (activeTab === 'queery') {
-                    setQueeries([...response.data]);
-                } else {
-                    setStories([...response.data]);
-                }
-            } catch (error) {
-                debugger;
-                console.error(error);
-            }
-        })();
-    }, [activeTab]);
 
     return (
         <Background>
@@ -73,59 +50,7 @@ export default function Homepage(props) {
                 <Spacer size={15}/>
                 <SearchAndFilter/>
                 <Spacer size={10}/>
-                <Tabs color="pink" value={activeTab} onTabChange={setActiveTab}>
-                    <Tabs.List grow>
-                        <Tabs.Tab value="queery"> Queeries </Tabs.Tab>
-                        <Tabs.Tab value="story">Stories </Tabs.Tab>
-                    </Tabs.List>
-
-                    <Tabs.Panel value="queery">
-                        {queeries === null ? (
-                            <div>Loading Queeries...</div>
-                        ) :
-                            (
-                                queeries.map((queery) => (
-                                    <>
-                                        <NewPost
-                                            key={queery.postId}
-                                            postId={queery.postId}
-                                            postType={queery.postType ?? 'Queery'}
-                                            username={queery.authorUser?.username ?? 'Anonymous'}
-                                            date={queery.createdAt}
-                                            title={queery.postTitle}
-                                            content={queery.postContent}
-                                            tags={queery.postTags}
-                                        />
-                                        <Spacer size={10}/>
-                                    </>
-                                ))
-                            )
-                        }
-                    </Tabs.Panel>
-                    <Tabs.Panel value="story">
-                        {stories === null ? (
-                            <div>Loading stories...</div>
-                        ) : (
-                            stories.map((story) => (
-
-                                <>
-                                    <NewPost
-                                        key={story.postId}
-                                        postId={story.postId}
-                                        postType={story.postType ?? 'Story'}
-                                        username={story.authorUser?.username ?? 'Anonymous'}
-                                        date={story.createdAt}
-                                        title={story.postTitle}
-                                        content={story.postContent}
-                                        tags={story.postTags}
-                                    />
-                                    <Spacer size={10}/>
-                                </>
-                            ))
-                        )
-                        }
-                    </Tabs.Panel>
-                </Tabs>
+                <QueeryStoryTabs />
             </StickyDiv>
         </Background>
     );

--- a/pages/homepage/index.js
+++ b/pages/homepage/index.js
@@ -1,23 +1,24 @@
 import axios from 'axios';
-import { Spacer } from '../../components/Atoms/Common/Spacer';
-import { NewPost } from '../../components/Templates/Post/NewPost';
-import { OTDBase } from '../../components/Templates/OfTheDay/OTDBase';
-import { queeryQuestions } from '../../data/qotd';
-import { API_SERVER } from '../../lib/constants';
-import { Background } from '../../styles/globals';
-import { SearchAndFilter } from '../../components/Organisms/Common/SearchAndFilter';
-import { Space, Tabs } from '@mantine/core';
+import {Spacer} from '../../components/Atoms/Common/Spacer';
+import {NewPost} from '../../components/Templates/Post/NewPost';
+import {OTDBase} from '../../components/Templates/OfTheDay/OTDBase';
+import {queeryQuestions} from '../../data/qotd';
+import {API_SERVER} from '../../lib/constants';
+import {Background} from '../../styles/globals';
+import {SearchAndFilter} from '../../components/Organisms/Common/SearchAndFilter';
+import {Space, Tabs} from '@mantine/core';
 import styled from 'styled-components';
 import {ScrollToTopButton} from '../../components/Atoms/Common/ScrollToTopButton';
-import {useEffect, useState} from 'react';
+import React, {useEffect, useState} from 'react';
+import {Loader} from '../../components/Atoms/Common/Loader';
 
 export const StickyDiv = styled.div`
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    background-color: #DFEEFF;
-    max-width: 50em;
-    margin: auto;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background-color: #DFEEFF;
+  max-width: 50em;
+  margin: auto;
 `;
 
 export default function Homepage(props) {
@@ -41,75 +42,91 @@ export default function Homepage(props) {
     // const [search, setSearch] = useState('');
     // const [filter, setFilter] = useState('All');
     // const [filteredPosts, setFilteredPosts] = useState([]);
-    const [activeTab, setActiveTab] = useState('Queery');
-    const [posts, setPosts] = useState([]); 
-   
+    const [activeTab, setActiveTab] = useState('queery');
 
-
+    const [stories, setStories] = useState(null);
+    const [queeries, setQueeries] = useState(null);
 
     useEffect(() => {
-        (async function() {
-            if (activeTab === 'Queery') {
-                const response = await axios.get(`${API_SERVER}/api/posts/queery`);
-                props.setPosts(response.data);
-            }
-            if (activeTab === 'Story') {
-                const response = await axios.get(`${API_SERVER}/api/posts/story`);
-                props.setPosts(response.data);
+        (async function () {
+            try {
+                console.log('fetching stories');
+                const response = await axios.get(`/api/posts/${activeTab}`);
+                console.log('response', response);
+                if (activeTab === 'queery') {
+                    setQueeries([...response.data]);
+                } else {
+                    setStories([...response.data]);
+                }
+            } catch (error) {
+                debugger;
+                console.error(error);
             }
         })();
-    }
-    );
+    }, [activeTab]);
 
     return (
         <Background>
-            <ScrollToTopButton isVisible={scrolledEnough} />
-            <OTDBase queeryQuestions={queeryQuestions.question} />
+            <ScrollToTopButton isVisible={scrolledEnough}/>
+            <OTDBase queeryQuestions={queeryQuestions.question}/>
             <StickyDiv>
-                <Spacer size={15} />
-                <SearchAndFilter />
-                <Spacer size={10} />
-                <Tabs color="pink" defaultValue="Queeries">
+                <Spacer size={15}/>
+                <SearchAndFilter/>
+                <Spacer size={10}/>
+                <Tabs color="pink" value={activeTab} onTabChange={setActiveTab}>
                     <Tabs.List grow>
-                        <Tabs.Tab value="Queeries" onClick={()=>setActiveTab('Queery')}> Queeries </Tabs.Tab>
-                        <Tabs.Tab value="Stories" onClick={()=>setActiveTab('Story')}>Stories </Tabs.Tab>
+                        <Tabs.Tab value="queery"> Queeries </Tabs.Tab>
+                        <Tabs.Tab value="story">Stories </Tabs.Tab>
                     </Tabs.List>
+
+                    <Tabs.Panel value="queery">
+                        {queeries === null ? (
+                            <div>Loading Queeries...</div>
+                        ) :
+                            (
+                                queeries.map((queery) => (
+                                    <>
+                                        <NewPost
+                                            key={queery.postId}
+                                            postId={queery.postId}
+                                            postType={queery.postType ?? 'Queery'}
+                                            username={queery.authorUser?.username ?? 'Anonymous'}
+                                            date={queery.createdAt}
+                                            title={queery.postTitle}
+                                            content={queery.postContent}
+                                            tags={queery.postTags}
+                                        />
+                                        <Spacer size={10}/>
+                                    </>
+                                ))
+                            )
+                        }
+                    </Tabs.Panel>
+                    <Tabs.Panel value="story">
+                        {stories === null ? (
+                            <div>Loading stories...</div>
+                        ) : (
+                            stories.map((story) => (
+
+                                <>
+                                    <NewPost
+                                        key={story.postId}
+                                        postId={story.postId}
+                                        postType={story.postType ?? 'Story'}
+                                        username={story.authorUser?.username ?? 'Anonymous'}
+                                        date={story.createdAt}
+                                        title={story.postTitle}
+                                        content={story.postContent}
+                                        tags={story.postTags}
+                                    />
+                                    <Spacer size={10}/>
+                                </>
+                            ))
+                        )
+                        }
+                    </Tabs.Panel>
                 </Tabs>
             </StickyDiv>
-            <Tabs.Panel value="Queeries">
-                {props.posts.map((post) => (
-                    <>
-                        <NewPost
-                            key={post.postId}
-                            postId={post.postId}
-                            postType={post.postType ?? 'Queery'}
-                            username={post.authorUser?.username ?? 'Anonymous'}
-                            date={post.createdAt}
-                            title={post.postTitle}
-                            content={post.postContent}
-                            tags={post.postTags}
-                        />
-                        <Spacer size={10} />
-                    </>
-                ))}
-            </Tabs.Panel>
-            <Tabs.Panel value="Stories">
-                {props.posts.map((post) => (
-                    <>
-                        <NewPost
-                            key={post.postId}
-                            postId={post.postId}
-                            postType={post.postType ?? 'Story'}
-                            username={post.authorUser?.username ?? 'Anonymous'}
-                            date={post.createdAt}
-                            title={post.postTitle}
-                            content={post.postContent}
-                            tags={post.postTags}
-                        />
-                        <Spacer size={10} />
-                    </>
-                ))}
-            </Tabs.Panel>
         </Background>
     );
 }
@@ -119,6 +136,6 @@ export async function getServerSideProps(context) {
     const posts = res.data;
     console.log(res.data);
     return {
-        props: { posts }, // will be passed to the page component as props
+        props: {posts}, // will be passed to the page component as props
     };
 }


### PR DESCRIPTION
* made a new organism called `QueeryStoryTabs` and put the loading and tabs logics in there
    * the reason for not putting it in homepage is because, i didn't want the whole page to be re-rendered every time the user changes the tab